### PR TITLE
Support for configuring mocha.setup() using Meteor.settings

### DIFF
--- a/preTest.js
+++ b/preTest.js
@@ -1,2 +1,6 @@
 //makes the bdd interface available (describe, it before, after, etc
-mocha.setup("bdd");
+if(Meteor.settings.public.mocha_setup_args) {
+    mocha.setup(Meteor.settings.public.mocha_setup_args);
+} else {
+    mocha.setup("bdd");
+}


### PR DESCRIPTION
settings.json: 

```
{
    "public": {
        "mocha_setup_args": {
            "ui": "bdd",
            "globals": ["script*"]
         }
    }
}
```

Start meteor using `--settings settings.json`to be able to pass options to `mocha.setup()` 

Using the setup arguments you can target any global leak problems and configure mocha to your likings. (https://github.com/mad-eye/meteor-mocha-web/issues/10)

Also this poses some sort of replacement for a mocha.opts file. (https://github.com/mad-eye/meteor-mocha-web/issues/11)
