### PR TITLE
Fixes issue when Mocha.settings is not available

### DIFF
--- a/preTest.js
+++ b/preTest.js
@@ -1,5 +1,5 @@
 //makes the bdd interface available (describe, it before, after, etc
-if(Meteor.settings.public.mocha_setup_args) {
+if(Meteor.settings && Meteor.settings.public.mocha_setup_args) {
     mocha.setup(Meteor.settings.public.mocha_setup_args);
 } else {
     mocha.setup("bdd");


### PR DESCRIPTION
I turned off the `insecure` and `autopublish` packages in Meteor, and the `mocha-web` package stopped working. Specifically, it gave the error:

```
Uncaught TypeError: Cannot read property 'public' of undefined 
```

On line 2 of `preTest.js`. I believe this is because the settings object is not published by default, unless one were to opt-in by [specifying some public settings](http://docs.meteor.com/#meteor_settings) to be available to the client.

In my fix, I test that the Mocha.settings object exists before preceding.
