### PR TITLE
Add the debugOnly flag and switch the api calls to be camelCased.

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,7 +1,8 @@
 Package.describe({
   name: 'mike:mocha',
   summary: "Run mocha tests in the browser",
-  version: "0.3.12",
+  version: "0.4.0",
+  debugOnly: true,
   git: "https://github.com/mad-eye/meteor-mocha-web"
 });
 
@@ -15,15 +16,15 @@ Npm.depends({
 //Require npm assertion library if it doesn't exist..
 //Npm.depends({chai: "1.9.0"});
 
-Package.on_use(function (api, where) {
+Package.onUse(function (api, where) {
   api.use(['velocity:core@0.2.14'], "server");
   api.use(['velocity:html-reporter@0.2.3'], "client");
   api.use(['templating@1.0.6'], "client");
 
-  api.add_files(["reporter.js", "server.js"], "server");
-  api.add_files(["client.html", "mocha.js", "reporter.js", "client.js", "chai.js"], "client");
+  api.addFiles(["reporter.js", "server.js"], "server");
+  api.addFiles(["client.html", "mocha.js", "reporter.js", "client.js", "chai.js"], "client");
 
-  api.add_files(["sample-tests/client.js","sample-tests/server.js"], "server", {isAsset: true});
+  api.addFiles(["sample-tests/client.js","sample-tests/server.js"], "server", {isAsset: true});
 
   api.export("MochaWeb", ["client", "server"]);
   api.export("MeteorCollectionTestReporter", ["client", "server"]);

--- a/versions.json
+++ b/versions.json
@@ -6,127 +6,127 @@
     ],
     [
       "application-configuration",
-      "1.0.2"
+      "1.0.3"
     ],
     [
       "base64",
-      "1.0.0"
+      "1.0.1"
     ],
     [
       "binary-heap",
-      "1.0.0"
+      "1.0.1"
     ],
     [
       "blaze",
-      "2.0.1"
+      "2.0.2"
     ],
     [
       "callback-hook",
-      "1.0.0"
+      "1.0.1"
     ],
     [
       "check",
-      "1.0.1"
+      "1.0.2"
     ],
     [
       "ddp",
-      "1.0.9"
+      "1.0.10"
     ],
     [
       "deps",
-      "1.0.4"
+      "1.0.5"
     ],
     [
       "ejson",
-      "1.0.3"
+      "1.0.4"
     ],
     [
       "follower-livedata",
-      "1.0.1"
+      "1.0.2"
     ],
     [
       "geojson-utils",
-      "1.0.0"
-    ],
-    [
-      "htmljs",
       "1.0.1"
     ],
     [
+      "htmljs",
+      "1.0.2"
+    ],
+    [
       "http",
-      "1.0.6"
-    ],
-    [
-      "id-map",
-      "1.0.0"
-    ],
-    [
-      "jquery",
-      "1.0.0"
-    ],
-    [
-      "json",
-      "1.0.0"
-    ],
-    [
-      "less",
-      "1.0.9"
-    ],
-    [
-      "logging",
-      "1.0.3"
-    ],
-    [
-      "meteor",
-      "1.1.1"
-    ],
-    [
-      "minimongo",
-      "1.0.3"
-    ],
-    [
-      "mongo",
-      "1.0.6"
-    ],
-    [
-      "observe-sequence",
-      "1.0.2"
-    ],
-    [
-      "ordered-dict",
-      "1.0.0"
-    ],
-    [
-      "random",
-      "1.0.0"
-    ],
-    [
-      "reactive-var",
-      "1.0.2"
-    ],
-    [
-      "retry",
-      "1.0.0"
-    ],
-    [
-      "templating",
       "1.0.7"
     ],
     [
+      "id-map",
+      "1.0.1"
+    ],
+    [
+      "jquery",
+      "1.0.1"
+    ],
+    [
+      "json",
+      "1.0.1"
+    ],
+    [
+      "less",
+      "1.0.10"
+    ],
+    [
+      "logging",
+      "1.0.4"
+    ],
+    [
+      "meteor",
+      "1.1.2"
+    ],
+    [
+      "minimongo",
+      "1.0.4"
+    ],
+    [
+      "mongo",
+      "1.0.7"
+    ],
+    [
+      "observe-sequence",
+      "1.0.3"
+    ],
+    [
+      "ordered-dict",
+      "1.0.1"
+    ],
+    [
+      "random",
+      "1.0.1"
+    ],
+    [
+      "reactive-var",
+      "1.0.3"
+    ],
+    [
+      "retry",
+      "1.0.1"
+    ],
+    [
+      "templating",
+      "1.0.8"
+    ],
+    [
       "tracker",
-      "1.0.2"
+      "1.0.3"
     ],
     [
       "underscore",
-      "1.0.0"
+      "1.0.1"
     ],
     [
       "url",
-      "1.0.0"
+      "1.0.1"
     ],
     [
       "velocity:core",
-      "0.2.14"
+      "0.3.0"
     ],
     [
       "velocity:html-reporter",
@@ -134,6 +134,6 @@
     ]
   ],
   "pluginDependencies": [],
-  "toolVersion": "meteor-tool@1.0.32",
+  "toolVersion": "meteor-tool@1.0.34",
   "format": "1.0"
 }


### PR DESCRIPTION
This should make sure we don't bundle mocha into production builds.

This should be tested, I am getting stuck at 'Loading' with a spinner when my tests should be running.
/cc @rissem 