### PR TITLE
Added mocha's `skip` and `only`

### DIFF
--- a/reporter.js
+++ b/reporter.js
@@ -42,6 +42,9 @@ MochaWeb.MeteorCollectionTestReporter = function(runner){
       ancestors: getAncestors(test),
       timestamp: new Date()
     };
+    if (typeof test.state === "undefined" && test.pending === true) {
+      result.result = "pending";
+    }
     if (test.err){
       result.failureMessage = test.err.message;
       result.failureStackTrace = test.err.stack;

--- a/server.js
+++ b/server.js
@@ -136,6 +136,8 @@ else {
     global.describe = function (name, func){
       mochaExports.describe(name, Meteor.bindEnvironment(func, function(err){throw err; }));
     };
+    global.describe.skip = mochaExports.describe.skip;
+    global.describe.only = mochaExports.describe.only;
 
     //In Meteor, these blocks will all be invoking Meteor code and must
     //run within a fiber. We must therefore wrap each with something like
@@ -168,6 +170,8 @@ else {
 
       mochaExports['it'](name, boundWrappedFunction);
     };
+    global.it.skip = mochaExports.it.skip;
+    global.it.only = mochaExports.it.only;
 
     ["before", "beforeEach", "after", "afterEach"].forEach(function(testFunctionName){
       global[testFunctionName] = function (func){


### PR DESCRIPTION
I forked https://github.com/CreepGin/meteor-mocha-web and removed the last commit which added the call to `resetReports`, which was why https://github.com/mad-eye/meteor-mocha-web/pull/80 was not merged.

I also issued the PR to `master` instead of the `velocity` branch.
