### PR TITLE
Rename 'time' => 'duration' to match latest velocity core

### DIFF
--- a/reporter.js
+++ b/reporter.js
@@ -37,7 +37,7 @@ MochaWeb.MeteorCollectionTestReporter = function(runner){
       name: test.title,
       pending: test.pending,
       result: test.state,
-      time: test.duration,
+      duration: test.duration,
       timeOut: test._timeout,
       timedOut: test.timedOut,
       ancestors: ancestors,


### PR DESCRIPTION
Per https://github.com/meteor-velocity/html-reporter/issues/38, this PR standardizes on "duration" to indicate test duration.
