### PR TITLE
fix async server test Fiber error

### DIFF
--- a/server.js
+++ b/server.js
@@ -40,12 +40,12 @@ else {
       ddpParentConnection = DDP.connect(parentUrl);
       console.log("Running mocha server tests");
       Meteor.call("velocity/reports/reset", function(err, result){
-        mocha.run(function(err){
+        mocha.run(Meteor.bindEnvironment(function(err){
           serverTestsComplete = true;
           if (clientTestsComplete){
             markTestsComplete();
           }
-        });
+        }));
       });
     } else {
       //HACK need to make sure after the proxy package adds the test files


### PR DESCRIPTION
The fiber error is reproduced [here](https://github.com/jfols/liftoff/tree/mocha-web).

``` console
W20141210-17:35:20.462(-5)? (STDERR) [velocity-mirror]
W20141210-17:35:20.462(-5)? (STDERR)
W20141210-17:35:20.463(-5)? (STDERR) [velocity-mirror] /Users/justin/dev/liftoff/.meteor/local/build/programs/server/packages/meteor.js:952
W20141210-17:35:20.463(-5)? (STDERR)
W20141210-17:35:20.463(-5)? (STDERR) [velocity-mirror]     throw new Error("Meteor code must always run within a Fiber. " +
W20141210-17:35:20.463(-5)? (STDERR)
W20141210-17:35:20.463(-5)? (STDERR) [velocity-mirror]     ^
W20141210-17:35:20.464(-5)? (STDERR)
W20141210-17:35:20.489(-5)? (STDERR) [velocity-mirror] Error: Meteor code must always run within a Fiber. Try wrapping callbacks that you pass to non-Meteor libraries with Meteor.bindEnvironment.
W20141210-17:35:20.490(-5)? (STDERR)     at Object.Meteor._nodeCodeMustBeInFiber (packages/meteor/dynamics_nodejs.js:9)
W20141210-17:35:20.490(-5)? (STDERR)     at Object.Meteor.bindEnvironment (packages/meteor/dynamics_nodejs.js:85)
W20141210-17:35:20.490(-5)? (STDERR)     at _.extend.apply (packages/ddp/livedata_connection.js:693)
W20141210-17:35:20.490(-5)? (STDERR)     at _.extend.call (packages/ddp/livedata_connection.js:643)
W20141210-17:35:20.490(-5)? (STDERR)     at markTestsComplete (packages/mike:mocha/server.js:67)
W20141210-17:35:20.492(-5)? (STDERR)     at packages/mike:mocha/server.js:46
W20141210-17:35:20.492(-5)? (STDERR)     at Runner.<anonymous> (/Users/justin/.meteor/packages/mike:mocha/.0.4.9.17x1wjq++os+web.browser+web.cordova/npm/node_modules/mocha/lib/runner.js:577:5)
W20141210-17:35:20.492(-5)? (STDERR)     at Runner.emit (events.js:117:20)
W20141210-17:35:20.497(-5)? (STDERR)     at /Users/justin/.meteor/packages/mike:mocha/.0.4.9.17x1wjq++os+web.browser+web.cordova/npm/node_modules/mocha/lib/runner.js:584:10
W20141210-17:35:20.497(-5)? (STDERR)     at /Users/justin/.meteor/packages/mike:mocha/.0.4.9.17x1wjq++os+web.browser+web.cordova/npm/node_modules/mocha/lib/runner.js:518:7
```

This definitely needs more testing, but appears to work.
