### PR TITLE
Set custom timeout limit per describe block

### DIFF
--- a/server.js
+++ b/server.js
@@ -173,9 +173,18 @@ else {
     mocha.suite.emit("pre-require", mochaExports);
     //console.log(mochaExports);
 
-    //patch up describe function so it plays nice w/ fibers
+    // 1. patch up describe function so it plays nice w/ fibers
+    // 2. trick to allow binding the suite instance as `this` value
+    // inside of describe blocks, to allow e.g. to set custom timeouts.
+    function wrapRunnable(func) {
+      return function() {
+        // `this` will be bound to the suite instance, as of Mocha's `describe` implementation
+        Meteor.bindEnvironment(func.bind(this), function(err) { throw err; })();
+      }
+    }
+
     global.describe = function (name, func){
-      mochaExports.describe(name, Meteor.bindEnvironment(func, function(err){throw err; }));
+      return mochaExports.describe(name, wrapRunnable(func));
     };
     global.describe.skip = mochaExports.describe.skip;
     global.describe.only = mochaExports.describe.only;


### PR DESCRIPTION
The issue was that the binding to the suite object inside of describe blocks was being lost because of the `Meteor.bindEnvironment` wrapping. Mocha binds the suite to the describe function block here: https://github.com/mochajs/mocha/blob/master/mocha.js#L1001.

I made a workaround so Mocha's binding could get through `Meteor.bindEnvironment`.

Not sure about how the function should be called, so I went with `wrapRunnable`.

With this fix, we will no longer get the global object as `this` value inside of `describe` blocks.

Fixes https://github.com/mad-eye/meteor-mocha-web/issues/82.