### PR TITLE
Adjusted "pre-require" emit to include the global mocha object.

### DIFF
--- a/server.js
+++ b/server.js
@@ -170,7 +170,7 @@ else {
 
 
     var mochaExports = {};
-    mocha.suite.emit("pre-require", mochaExports);
+    mocha.suite.emit("pre-require", mochaExports, null, global.mocha);
     //console.log(mochaExports);
 
     //patch up describe function so it plays nice w/ fibers


### PR DESCRIPTION
Hi - I noticed **it.only** wasn't working for my tests. Tracing through the code it looks like **mocha** is undefined as it isn't passed in when the **"pre-require"** event is called in server.js. I see that it's defined as a global in server.js so I've adjusted things to pass the defined Mocha object in through the "pre-require" emit. This should help fix issue #81.