### PR TITLE
Fix mirror url

### DIFF
--- a/server.js
+++ b/server.js
@@ -62,7 +62,8 @@ else {
       Meteor.setTimeout(function(){
         Meteor.call("velocity/mirrors/request", {
           framework: 'mocha',
-          testsPath: "mocha"
+          testsPath: "mocha",
+          rootUrlPath: '/?mocha=true'
         }, function(err, msg){
           if (err){
             console.log("error requesting mirror", err);


### PR DESCRIPTION
After updating to Velocity 0.6.0, I was getting this error:

![screenshot 2015-04-19 11 51 30](https://cloud.githubusercontent.com/assets/816517/7220121/7e3042f8-e68a-11e4-8b53-4fd1b51da12a.png)

It looks like Velocity doesn't default to adding the framework name to the mirror url anymore. This fixes that.