### PR TITLE
server: preserve mocha options on the server

### DIFF
--- a/server.js
+++ b/server.js
@@ -86,7 +86,12 @@ if (Velocity && Velocity.registerTestingFramework){
     global.chai = Npm.require("chai");
     // enable stack trace with line numbers with assertions
     global.chai.Assertion.includeStack = true;
-    global.mocha = new Mocha({ui: "bdd", reporter: MochaWeb.MeteorCollectionTestReporter});
+    opts = {};
+    if (typeof global.mocha !== 'undefined') {
+      opts = _.extend(opts, global.mocha.options);
+    }
+    opts = _.extend(opts, {ui: "bdd", reporter: MochaWeb.MeteorCollectionTestReporter});
+    global.mocha = new Mocha(opts);
     setupGlobals();
   }
 


### PR DESCRIPTION
This may be useful to configure `mocha.grep(...)` to select a subset of
tests.  Previously, this worked only on the client, because the mocha
options got lost when instantiating `Mocha` for the server.