### PR TITLE
Fix running tests twice in parallel due to rapid-fire mocha events.

### DIFF
--- a/server.js
+++ b/server.js
@@ -36,7 +36,8 @@ Meteor.startup(function(){
     parentUrl = process.env.PARENT_URL;
     ddpParentConnection = DDP.connect(parentUrl);
 
-    runServerTests = Meteor.bindEnvironment(function() {
+    var debounce = 1000; // one second should be enough; mocha often sends changed() right after added().
+    runServerTests = _.debounce(Meteor.bindEnvironment(function() {
       console.log("Running mocha server tests");
       mocha.run(Meteor.bindEnvironment(function(err){
         if (err){
@@ -44,7 +45,7 @@ Meteor.startup(function(){
         }
         markTestsComplete();
       }));
-    });
+    }), debounce);
   } else {
     mirrorPort = process.env.MOCHA_MIRROR_PORT;
     opt = {


### PR DESCRIPTION
I found that meteor mocha was running my tests twice in parallel almost all the time. This was caused by the mocha observer getting a changed() call right after the added() call. Putting in a one-second debounce fixes it.
