### PR TITLE
Fix to prevent security exception in FlowRouter

### DIFF
--- a/server.js
+++ b/server.js
@@ -50,7 +50,7 @@ Meteor.startup(function(){
     opt = {
       framework: 'mocha',
       testsPath: "mocha",
-      rootUrlPath: '/?mocha=true',
+      rootUrlPath: '?mocha=true',
     }
     if(mirrorPort) {
       opt['port'] = parseInt(mirrorPort);


### PR DESCRIPTION
Fixes #173 

The extra slash was causing a double slash to be generated in the URL (i.e. `http://localhost:8568//?mocha=true`), which causes problems in flow-router.